### PR TITLE
Update sps30.py

### DIFF
--- a/sps30/sps30.py
+++ b/sps30/sps30.py
@@ -37,6 +37,7 @@ class SPS30:
     def start_measurement(self):
         cmd = bytearray([0x00, 0x10, 0x03, 0x00, self.calc_crc8([0x03, 0x00])])
         self.i2c.writeto(self.address, cmd) # measurement mode
+        time.sleep(1)
         self.i2c.writeto(self.address, bytearray([0x56, 0x07])) #cleanup
         time.sleep(10)
         


### PR DESCRIPTION
Fixes an error with pico 2

with the added sleep it works

"
Traceback (most recent call last):
  File "<stdin>", line 118, in <module>
  File "<stdin>", line 40, in start_measurement
OSError: [Errno 5] EIO
"